### PR TITLE
메인페이지 스크롤 버그 해결

### DIFF
--- a/app/features/home/index.module.scss
+++ b/app/features/home/index.module.scss
@@ -10,6 +10,8 @@
 
   width: 100%;
   height: 100dvh;
+  padding: 0 12px;
+  box-sizing: border-box; // padding을 포함하여 width를 계산
 
   .main-text {
     font-size: 75px;


### PR DESCRIPTION
기본 box-sizing은 padding을 포함해서 계산하지 않습니다.

box-sizing: border-box를 사용해서 width를 계산하도록 합니다.