### PR TITLE
SearchSongPage 이동

### DIFF
--- a/app/features/profile/components/SearchSongInput.tsx
+++ b/app/features/profile/components/SearchSongInput.tsx
@@ -10,7 +10,7 @@ interface Props {
   onSelect?: (song: MusicInfo, index: number) => void;
 }
 
-export default function SearchSongPage({ onSelect }: Props) {
+export default function SearchSongInput({ onSelect }: Props) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<MusicInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/app/features/profile/pages/addTodaySong.tsx
+++ b/app/features/profile/pages/addTodaySong.tsx
@@ -5,7 +5,8 @@ import type { MusicInfo } from 'app/external/music/IMusicSearchAPI';
 import { type SimpleSong } from 'app/features/profile/components/SongItem';
 import SongItem from 'app/features/profile/components/SongItem';
 import styles from 'app/features/profile/pages/addTodaySong.module.scss';
-import SearchSongPage from 'app/routes/profile.$userId.searchSong';
+
+import SearchSongInput from '../components/SearchSongInput';
 
 interface AddTodaySongProps {
   initialSong: SimpleSong | null;
@@ -44,7 +45,7 @@ export default function AddTodaySongPage({ initialSong }: AddTodaySongProps) {
 
       <section className={styles.searchSection}>
         <h2>노래 검색</h2>
-        <SearchSongPage onSelect={handleSongPicked} />
+        <SearchSongInput onSelect={handleSongPicked} />
       </section>
 
       {previewSong && (


### PR DESCRIPTION
SearchSongPage 컴포넌트는 routes에 들어갈 이유가 없습니다.

Component로 이동시키고 SearchSongInput으로 이름을 바꿉니다.