### PR TITLE
feat(profile): 초기 로그인 시 핸들 설정 기능 구현 (editHandle)

### DIFF
--- a/app/features/auth/loader.tsx
+++ b/app/features/auth/loader.tsx
@@ -25,13 +25,13 @@ export const authCallbackLoader = createLoader(async ({ request }) => {
     secure: process.env.NODE_ENV === 'production',
   });
 
-  return redirect(`/profile/${user.id}/show`, {
+  const redirectTarget = user.handle.startsWith('google-')
+    ? `/profile/${user.id}/editHandle`
+    : `/profile/${user.id}/show`;
+
+  return redirect(redirectTarget, {
     headers: {
       'Set-Cookie': jwtCookie,
     },
   });
-});
-
-export const googleAuthLoader = createLoader(async ({ request }) => {
-  return authenticator.authenticate('google', request);
 });

--- a/app/features/profile/action.ts
+++ b/app/features/profile/action.ts
@@ -1,6 +1,6 @@
-import { redirect } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
 
-import { findUserByHandle } from 'app/features/profile/services';
+import { findUserByHandle, updateUserHandle } from 'app/features/profile/services';
 import createAction from 'app/utils/createAction';
 
 export const addTodaySongAction = createAction(async ({ request, db, params }) => {
@@ -42,4 +42,25 @@ export const addTodaySongAction = createAction(async ({ request, db, params }) =
   });
 
   return redirect('../show');
+});
+
+export const editHandleAction = createAction(async ({ request, db }) => {
+  const formData = await request.formData();
+  const handle = formData.get('handle')?.toString();
+  const userId = formData.get('userId')?.toString();
+
+  if (!userId) {
+    return redirect('/login?error=사용자 정보를 불러올 수 없습니다.');
+  }
+
+  if (typeof handle !== 'string' || handle.trim().length === 0) {
+    return data({ error: '핸들을 입력해주세요.' }, { status: 400 });
+  }
+
+  try {
+    await updateUserHandle(db)({ userId, handle });
+    return redirect(`/profile/${userId}/show`);
+  } catch (err) {
+    return data({ error: (err as Error).message }, { status: 400 });
+  }
 });

--- a/app/features/profile/loader.ts
+++ b/app/features/profile/loader.ts
@@ -73,3 +73,12 @@ export const searchLoader = createLoader(async ({ db, request }) => {
 
   return { users };
 });
+
+export const editHandleLoader = createLoader(async ({ request }) => {
+  const user = await getCurrentUser(request);
+  if (!user) {
+    throw redirect('/login/error', { status: 401 });
+  }
+
+  return { userId: user.id };
+});

--- a/app/features/profile/pages/editHandle.module.scss
+++ b/app/features/profile/pages/editHandle.module.scss
@@ -1,0 +1,44 @@
+.container {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 2rem;
+  background-color: #f9f9f9;
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.submit-button {
+  padding: 0.6rem;
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.submit-button:hover {
+  background-color: #0058c7;
+}
+
+.error {
+  color: red;
+  font-size: 0.9rem;
+}

--- a/app/features/profile/pages/editHandle.tsx
+++ b/app/features/profile/pages/editHandle.tsx
@@ -1,0 +1,23 @@
+import { useActionData, useLoaderData } from '@remix-run/react';
+
+import { editHandleLoader } from '../loader';
+import styles from './editHandle.module.scss';
+
+export default function EditHandlePage() {
+  const loaderData = useLoaderData<typeof editHandleLoader>();
+  const actionData = useActionData<{ error?: string }>();
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>핸들 설정</h1>
+      <form method="post">
+        <input type="text" name="handle" placeholder="핸들을 입력하세요" required className={styles.formInput} />
+        <input type="hidden" name="userId" value={loaderData.userId} />
+        {actionData?.error && <p className={styles.error}>{actionData.error}</p>}
+        <button type="submit" className={styles.submitButton}>
+          저장
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/features/profile/services.ts
+++ b/app/features/profile/services.ts
@@ -66,3 +66,19 @@ export const findUserByHandleSim = createService<{ handle: string }, User[]>(asy
   });
   return user;
 });
+
+export const updateUserHandle = createService<{ userId: string; handle: string }, User>(
+  async (db, { userId, handle }) => {
+    const existingUser = await db.user.findUnique({
+      where: { handle },
+    });
+
+    if (existingUser && existingUser.id !== parseInt(userId)) {
+      throw new Error('이미 사용 중인 handle입니다.');
+    }
+    return db.user.update({
+      where: { id: parseInt(userId) },
+      data: { handle },
+    });
+  }
+);

--- a/app/routes/profile.$userId.editHandle.tsx
+++ b/app/routes/profile.$userId.editHandle.tsx
@@ -1,0 +1,12 @@
+import type { MetaFunction } from '@remix-run/node';
+
+import { editHandleAction } from 'app/features/profile/action';
+import { editHandleLoader } from 'app/features/profile/loader';
+import EditHandlePage from 'app/features/profile/pages/editHandle';
+
+export const meta: MetaFunction = () => [{ title: '핸들 설정' }];
+
+export const loader = editHandleLoader;
+export const action = editHandleAction;
+
+export default EditHandlePage;


### PR DESCRIPTION
### 구현 내용
- 사용자 최조 로그인 시 handle이 `google-...`으로 설정되고, 강제로 핸들 설정 페이지로 이동
   - `/profile/${user.id}/editHandle`로 리디렉트
- 불필요한 로더 제거

### 주요 기능 설명
- `routes/profile.$userId.editHandle.tsx`: loader, action, meta 설정
- `features/profile/pages/editHandle.tsx`: 핸들 입력 폼 UI 구성
- `editHandleLoader`: JWT기반 사용자 인증 및 userId 추출 (`features/profile/loader.tsx`)
- `updateUserHandle`: 중복된 핸들 검증 및 업데이트 처리 (`features/profile/services.ts`)
- `editHandleAction`: 유효한 핸들 입력 받아 `updateUserHandle` 호출후 show페이지로 리디렉트 (`features/profile/services.ts`)

#68 