### PR TITLE
feat(search): 검색 페이지 UI 및 추천 사용자 목록 구현

### DIFF
--- a/app/features/profile/components/Icons.tsx
+++ b/app/features/profile/components/Icons.tsx
@@ -1,0 +1,53 @@
+export const MusicNoteIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M9 18V5l12-2v13"></path>
+    <circle cx="6" cy="18" r="3"></circle>
+    <circle cx="18" cy="16" r="3"></circle>
+  </svg>
+);
+
+export const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <circle cx="11" cy="11" r="8"></circle>
+    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+  </svg>
+);
+
+export const ChevronRightIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <polyline points="9 18 15 12 9 6"></polyline>
+  </svg>
+);

--- a/app/features/profile/components/ProfileCard.module.scss
+++ b/app/features/profile/components/ProfileCard.module.scss
@@ -1,0 +1,116 @@
+.card {
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: block;
+  border: 1px solid #f1f3f5;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.04);
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.cardTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.profileInfo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.userInfo {
+  .handle {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #212529;
+  }
+  .name {
+    font-size: 0.8rem;
+    color: #868e96;
+  }
+}
+
+.chevron {
+  color: #ced4da;
+  transition: transform 0.2s;
+
+  .card:hover & {
+    transform: translateX(3px);
+  }
+}
+
+.todaysPick {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background-color: #f8f9fa;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.songThumbnail {
+  width: 36px;
+  height: 36px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.songText {
+  min-width: 0;
+  .song {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #495057;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .artist {
+    font-size: 0.75rem;
+    color: #adb5bd;
+  }
+}
+
+.noSongPlaceholder {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background-color: #f8f9fa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 52px;
+  svg {
+    width: 18px;
+    height: 18px;
+    color: #ced4da;
+  }
+  p {
+    font-size: 0.8rem;
+    color: #adb5bd;
+  }
+}

--- a/app/features/profile/components/ProfileCard.tsx
+++ b/app/features/profile/components/ProfileCard.tsx
@@ -1,0 +1,49 @@
+import { Link } from '@remix-run/react';
+
+import { ChevronRightIcon, MusicNoteIcon } from './Icons';
+import styles from './ProfileCard.module.scss';
+import { UserWithRecommendedSong } from '../services';
+
+export function ProfileCard({ user }: { user: UserWithRecommendedSong }) {
+  return (
+    <Link to={`/profile/${user.id}/show`} key={user.id} className={styles.card}>
+      <div className={styles.cardTop}>
+        <div className={styles.profileInfo}>
+          <img
+            src={'https://placehold.co/40x40/ecf0f1/bdc3c7?text=...'} // TODO: avartarUrl 넣기
+            alt={`${user.name}의 프로필 사진`}
+            className={styles.avatar}
+          />
+          <div className={styles.userInfo}>
+            <p className={styles.handle}>@{user.handle}</p>
+            <p className={styles.name}>{user.name}</p>
+          </div>
+        </div>
+        <div className={styles.chevron}>
+          <ChevronRightIcon />
+        </div>
+      </div>
+
+      {user.todayRecommendedSong ? (
+        <div className={styles.todaysPick}>
+          <img
+            src={user.todayRecommendedSong.thumbnailUrl ?? 'https://placehold.co/36x36/ecf0f1/bdc3c7?text=...'}
+            alt={`${user.todayRecommendedSong.artist} - ${user.todayRecommendedSong.title} 앨범 아트`}
+            className={styles.songThumbnail}
+          />
+          <div className={styles.songText}>
+            <p className={styles.song} title={user.todayRecommendedSong.title}>
+              {user.todayRecommendedSong.title}
+            </p>
+            <p className={styles.artist}>{user.todayRecommendedSong.artist}</p>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.noSongPlaceholder}>
+          <MusicNoteIcon />
+          <p>추천곡 없음</p>
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/app/features/profile/loader.ts
+++ b/app/features/profile/loader.ts
@@ -1,3 +1,4 @@
+import { data } from '@remix-run/node';
 import { redirect } from '@remix-run/react';
 
 import { authenticator } from 'app/external/auth/auth.server';
@@ -5,7 +6,12 @@ import { getCurrentUser } from 'app/external/auth/jwt.server';
 import createLoader from 'app/utils/createLoader';
 
 import { searchSongInputLoader } from './components/SearchSongInput';
-import { fetchUserWithRecomandSong, fetchUserWithUserRankings, findUserByHandleSim } from './services';
+import {
+  fetchUserWithRecomandSong,
+  fetchUserWithUserRankings,
+  findUserByHandleSim,
+  getRecommendedUsers,
+} from './services';
 
 export const profileLoader = createLoader(async ({ db, params }) => {
   const userId = Number(params.userId);
@@ -63,15 +69,15 @@ export const addTodaySongLoader = createLoader(async ({ db, params, request }) =
 
 export const searchLoader = createLoader(async ({ db, request }) => {
   const url = new URL(request.url);
-  const search = new URLSearchParams(url.search);
-  const handle = search.get('handle');
-
-  if (!handle) {
-    return { users: [] };
-  }
-  const users = await findUserByHandleSim(db)({ handle });
-
-  return { users };
+  const handle = url.searchParams.get('handle');
+  const recommendedUsersPromise = getRecommendedUsers(db)();
+  const searchResultsPromise = handle ? findUserByHandleSim(db)({ handle }) : Promise.resolve(null);
+  const [recommendedUsers, searchResults] = await Promise.all([recommendedUsersPromise, searchResultsPromise]);
+  return data({
+    recommendedUsers,
+    searchResults,
+    query: handle,
+  });
 });
 
 export const editHandleLoader = createLoader(async ({ request }) => {

--- a/app/features/profile/pages/search.module.scss
+++ b/app/features/profile/pages/search.module.scss
@@ -1,8 +1,94 @@
-@use 'styles/layout' as *;
+.wrapper {
+  padding: 2rem 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
 
-.searchWrapper {
+.searchContainer {
   display: flex;
-  flex-direction: column;
-  padding: 36px 24px;
-  gap: 16px;
+  gap: 0.5rem;
+  margin-bottom: 2.5rem;
+  margin-top: 2rem;
+  align-items: center;
+}
+
+.searchInputWrapper {
+  position: relative;
+  flex-grow: 1;
+
+  svg {
+    position: absolute;
+    left: 0.8rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #adb5bd;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.searchInput {
+  width: 93%;
+  height: 39px;
+  border-radius: 8px;
+  border: 1px solid #dee2e6;
+  padding: 0.5rem 1rem 0.5rem 2.5rem;
+  font-size: 0.95rem;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: #4dabf7;
+    box-shadow: 0 0 0 3px rgba(77, 171, 247, 0.2);
+  }
+}
+
+.searchButton {
+  background-color: #4dabf7;
+  color: #fff;
+  border: none;
+  width: 65px;
+  height: 55px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background-color: #339af0;
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  color: #343a40;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.profileGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+
+  @media (max-width: 900px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
 }

--- a/app/features/profile/pages/search.tsx
+++ b/app/features/profile/pages/search.tsx
@@ -1,26 +1,60 @@
-import { Form, Link, useLoaderData } from '@remix-run/react';
+import { useLoaderData, Form } from '@remix-run/react';
 
 import styles from './search.module.scss';
+import { SearchIcon } from '../components/Icons';
+import { ProfileCard } from '../components/ProfileCard';
 import { searchLoader } from '../loader';
 
-export default function Search() {
-  const { users } = useLoaderData<typeof searchLoader>();
+export default function SearchPage() {
+  const { recommendedUsers, searchResults, query } = useLoaderData<typeof searchLoader>();
+
+  const isSearchMode = !!query;
 
   return (
-    <div className={styles.searchWrapper}>
-      <Form>
-        <input type="text" name="handle" />
-        <button type="submit">검색</button>
+    <div className={styles.wrapper}>
+      <h1>User Search</h1>
+
+      <Form method="get" action="/profile/search" className={styles.searchContainer}>
+        <div className={styles.searchInputWrapper}>
+          <SearchIcon className={styles.searchIcon} />
+          <input
+            type="text"
+            name="handle"
+            placeholder="사용자 핸들 검색..."
+            className={styles.searchInput}
+            defaultValue={query ?? ''}
+          />
+        </div>
+        <button type="submit" className={styles.searchButton}>
+          <SearchIcon />
+        </button>
       </Form>
-      <ul>
-        {users.map((user) => (
-          <Link key={user.id} to={`/profile/${user.id}/show`}>
-            <li>
-              {user.name}({user.handle})
-            </li>
-          </Link>
-        ))}
-      </ul>
+
+      <hr />
+
+      {isSearchMode ? (
+        <div>
+          <h2 className={styles.title}>{`🔍 검색 결과"${query}"`}</h2>
+          {searchResults && searchResults.length > 0 ? (
+            <div className={styles.profileGrid}>
+              {searchResults.map((user) => (
+                <ProfileCard key={user.id} user={user} />
+              ))}
+            </div>
+          ) : (
+            <p> {`"${query}"에 대한 검색 결과가 없습니다.`}</p>
+          )}
+        </div>
+      ) : (
+        <div>
+          <h2 className={styles.title}>✨ 오늘의 추천 프로필</h2>
+          <div className={styles.profileGrid}>
+            {recommendedUsers.map((user) => (
+              <ProfileCard key={user.id} user={user} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/features/profile/services.ts
+++ b/app/features/profile/services.ts
@@ -55,17 +55,32 @@ export const findUserByHandle = createService<{ handle: string }, User | null>(a
   return user;
 });
 
-export const findUserByHandleSim = createService<{ handle: string }, User[]>(async (db, args) => {
-  const user = await db.user.findMany({
+export const findUserByHandleSim = createService<{ handle: string }, UserWithRecommendedSong[]>(async (db, args) => {
+  const users = await db.user.findMany({
     where: {
       handle: {
         contains: args.handle,
         mode: 'insensitive',
       },
     },
+    include: { todayRecommendedSong: true },
   });
-  return user;
+  return users;
 });
+
+export const getRecommendedUsers = createService<Record<string, never>, UserWithRecommendedSong[]>(
+  async (db, _args) => {
+    const users = await db.user.findMany({
+      take: 6,
+      include: { todayRecommendedSong: true },
+    });
+    // TODO: avatarUrl 추가 필요(현재는 랜덤)
+    return users.map((user) => ({
+      ...user,
+      avatarUrl: `https://i.pravatar.cc/150?u=${user.handle}`,
+    }));
+  }
+);
 
 export const updateUserHandle = createService<{ userId: string; handle: string }, User>(
   async (db, { userId, handle }) => {


### PR DESCRIPTION
### 💻 변경 내용
- `findRecommendedUsers` 서비스 추가: 추천 사용자 6명의 프로필(id, name, handle 등)을 DB에서 가져오는 서비스 구현
- `searchLoader`구현: 페이지 진입 시 `findRecommendedUsers`서비스를 호출하여 추천 사용자 목록을 로드하는 로더
-  `/profile/pages/search`: 검색 페이지 UI 구현 
- ~~`RecommendedUser` 타입 정의: `/types/user.ts`에 추천 프로필 인터페이스 정의~~

---- 추가 수정 ----
- `Icons.tsx` 컴포넌트 추가
- `ProfileCard` 컴포넌트 추가
- `findUserByHandleSim` 서비스 반환값 수정: `User[]` -> `UserWithRecommendedSong[]`
   - `ProfileCard` 컴포넌트 재사용하기 위해
 
[기본 search 페이지]
<img width="1125" height="666" alt="image" src="https://github.com/user-attachments/assets/745b44cc-d1a2-41d9-8cc9-a6b34255db4c" />
[검색 시: 결과 O]
<img width="1940" height="1182" alt="image" src="https://github.com/user-attachments/assets/55664a90-b4be-4a84-a39d-af2a3419c0fe" />
[검색 시: 결과 X]
<img width="1990" height="928" alt="image" src="https://github.com/user-attachments/assets/2a41c6e9-deb2-49f8-84ed-f42de1f73e0f" />


### 💡 남은 작업
- [x] `searchLoader`에 검색 쿼리(`?handle=...`)처리 로직 추가
- [x] `findUserByHandleSim`서비스 사용하여 실제 검색 결과 반환
- [x] 검색 결과가 있을 경우와 없을 경우에 대한 UI 분기 처리
- [ ] db에 `avatarUrl`필드 생성 후, 서비스 함수 수정
