### PR TITLE
앨범 커버 타임아웃 생기면 기본 이미지 표시

### DIFF
--- a/app/external/music/musicBrainz.ts
+++ b/app/external/music/musicBrainz.ts
@@ -16,6 +16,11 @@ export class MusicBrainzAPI {
         throw error;
       }
 
+      if (error.code === 'ECONNABORTED') {
+        console.warn('Cover art request timed out');
+        return '';
+      }
+
       if (error.response?.status === 404) {
         return '';
       }


### PR DESCRIPTION
지금은 타임아웃이 생기면 에러가 발생합니다.
기본 이미지를 표시하도록 합니다.