### PR TITLE
feat(handle): 핸들 유효성 검사 기능 추가

### DIFF
--- a/app/features/profile/action.ts
+++ b/app/features/profile/action.ts
@@ -3,6 +3,8 @@ import { data, redirect } from '@remix-run/node';
 import { findUserByHandle, updateUserHandle } from 'app/features/profile/services';
 import createAction from 'app/utils/createAction';
 
+import { HandleSchema } from './schema';
+
 export const addTodaySongAction = createAction(async ({ request, db, params }) => {
   const formData = await request.formData();
 
@@ -46,20 +48,21 @@ export const addTodaySongAction = createAction(async ({ request, db, params }) =
 
 export const editHandleAction = createAction(async ({ request, db }) => {
   const formData = await request.formData();
-  const handle = formData.get('handle')?.toString();
-  const userId = formData.get('userId')?.toString();
 
-  if (!userId) {
-    return redirect('/login?error=사용자 정보를 불러올 수 없습니다.');
-  }
+  const formPayload = {
+    userId: formData.get('userId'),
+    handle: formData.get('handle'),
+  };
 
-  if (typeof handle !== 'string' || handle.trim().length === 0) {
-    return data({ error: '핸들을 입력해주세요.' }, { status: 400 });
+  const result = HandleSchema.safeParse(formPayload);
+
+  if (!result.success) {
+    return data({ error: result.error.issues[0].message }, { status: 400 });
   }
 
   try {
-    await updateUserHandle(db)({ userId, handle });
-    return redirect(`/profile/${userId}/show`);
+    await updateUserHandle(db)({ userId: result.data.userId, handle: result.data.handle });
+    return redirect(`/profile/${result.data.userId}/show`);
   } catch (err) {
     return data({ error: (err as Error).message }, { status: 400 });
   }

--- a/app/features/profile/hook/useHandleValidation.ts
+++ b/app/features/profile/hook/useHandleValidation.ts
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import { HandleCharacterSchema, HandleSchema } from '../schema';
+
+export function useHandleValidation() {
+  const [handle, setHandle] = useState('');
+  const [clientError, setClientError] = useState('');
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    const result = HandleCharacterSchema.safeParse(newValue);
+
+    if (!result.success) {
+      setClientError(result.error.issues[0].message);
+    } else {
+      setClientError('');
+    }
+
+    const sanitizedValue = newValue.replace(/[^a-zA-Z0-9_]/g, '');
+    setHandle(sanitizedValue);
+  };
+
+  const handleInputBlur = () => {
+    if (handle.length > 0) {
+      const result = HandleSchema.pick({ handle: true }).safeParse({ handle });
+      if (!result.success) {
+        setClientError(result.error.issues[0].message);
+      } else {
+        setClientError('');
+      }
+    }
+  };
+
+  return {
+    handle,
+    clientError,
+    handleInputChange,
+    handleInputBlur,
+  };
+}

--- a/app/features/profile/pages/editHandle.module.scss
+++ b/app/features/profile/pages/editHandle.module.scss
@@ -38,7 +38,27 @@
   background-color: #0058c7;
 }
 
+.formRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.formInput[aria-invalid='true'] {
+  border-color: #e53e3e;
+  &:focus {
+    border-color: #e53e3e;
+    box-shadow: 0 0 0 1px #e53e3e;
+  }
+}
+
+.errorContainer {
+  min-height: 24px;
+  margin-top: 8px;
+}
+
 .error {
-  color: red;
-  font-size: 0.9rem;
+  color: #e53e3e;
+  font-size: 14px;
+  margin: 0;
 }

--- a/app/features/profile/pages/editHandle.tsx
+++ b/app/features/profile/pages/editHandle.tsx
@@ -2,21 +2,41 @@ import { Form, useActionData, useLoaderData } from '@remix-run/react';
 
 import { editHandleLoader } from '../loader';
 import styles from './editHandle.module.scss';
+import { editHandleAction } from '../action';
+import { useHandleValidation } from './useHandleValidation';
 
 export default function EditHandlePage() {
   const loaderData = useLoaderData<typeof editHandleLoader>();
-  const actionData = useActionData<{ error?: string }>();
+  const actionData = useActionData<typeof editHandleAction>();
+
+  const { handle, clientError, handleInputChange, handleInputBlur } = useHandleValidation();
 
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>핸들 설정</h1>
       <Form method="post">
-        <input type="text" name="handle" placeholder="핸들을 입력하세요" required className={styles.formInput} />
+        <div className={styles.formRow}>
+          <input
+            type="text"
+            name="handle"
+            placeholder="핸들을 입력하세요"
+            required
+            className={styles.formInput}
+            value={handle}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            aria-invalid={!!(clientError || actionData?.error)}
+          />
+          <button type="submit" className={styles.submitButton}>
+            저장
+          </button>
+        </div>
+
         <input type="hidden" name="userId" value={loaderData.userId} />
-        {actionData?.error && <p className={styles.error}>{actionData.error}</p>}
-        <button type="submit" className={styles.submitButton}>
-          저장
-        </button>
+
+        <div className={styles.errorContainer}>
+          {(clientError || actionData?.error) && <p className={styles.error}>{clientError || actionData?.error}</p>}
+        </div>
       </Form>
     </div>
   );

--- a/app/features/profile/pages/useHandleValidation.ts
+++ b/app/features/profile/pages/useHandleValidation.ts
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import { HandleCharacterSchema, HandleSchema } from '../schema';
+
+export function useHandleValidation() {
+  const [handle, setHandle] = useState('');
+  const [clientError, setClientError] = useState('');
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    const result = HandleCharacterSchema.safeParse(newValue);
+
+    if (!result.success) {
+      setClientError(result.error.issues[0].message);
+    } else {
+      setClientError('');
+    }
+
+    const sanitizedValue = newValue.replace(/[^a-zA-Z0-9_]/g, '');
+    setHandle(sanitizedValue);
+  };
+
+  const handleInputBlur = () => {
+    if (handle.length > 0) {
+      const result = HandleSchema.pick({ handle: true }).safeParse({ handle });
+      if (!result.success) {
+        setClientError(result.error.issues[0].message);
+      } else {
+        setClientError('');
+      }
+    }
+  };
+
+  return {
+    handle,
+    clientError,
+    handleInputChange,
+    handleInputBlur,
+  };
+}

--- a/app/features/profile/schema.ts
+++ b/app/features/profile/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const HandleCharacterSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9_]*$/, '핸들은 영문, 숫자, 언더스코어(_)만 사용할 수 있습니다.');
+
+export const HandleSchema = z.object({
+  userId: z.string().nonempty('사용자 ID가 필요합니다.'),
+  handle: z
+    .string({
+      required_error: '핸들을 입력해주세요.',
+    })
+    .min(3, '핸들은 3자 이상이어야 합니다.')
+    .regex(/^[a-zA-Z0-9_]+$/, '핸들은 영문, 숫자, 언더스코어(_)만 사용할 수 있습니다.'),
+});


### PR DESCRIPTION
## 📖 개요 
핸들 설정 페이지의 유효성 검사 로직 추가

## 💻 변경 내용
**1. 유효성 검사 로직 도입 (`action.ts`, `schema.ts`)**
   - `HandleCharacterSchema`: 사용자가 입력할 때마다 검사
   - `HandleSchema`: 사용자가 입력을 완료 후 검사 

**2. 3단계 클라이언트 유효성 검사**
   - `onChange`(실시간): 허용되지 않는 문자 입력을 실시간으로 막고 에러 메시지 표시
   - `onBlur`(입력 완료 시): 사용자가 입력 창을 벗어났을 때, 글자 수 등 완성형 규칙 검사
   - `onSubmit`(서버 응답): 서버 측 `action`에서 반환된 에러(예: 중복 핸들)를 표시

**3. 커스텀 훅 `useHandleValidation`으로 로직 분리 (`useHandleValidation.ts`, `editHandle.tsx`)**
   - `editHandle.tsx`컴포넌트에서 사용하는 `useState`와 유효성 검사 로직을 `useHandleValidation` 커스텀 훅으로 분리

## 📸 Screen Shot
1. 허용되지 않는 문자 입력 시도시, 입력 차단 및 에러 메시지
<img width="1104" height="402" alt="image" src="https://github.com/user-attachments/assets/36b209fe-a7b1-47d3-b670-825d97b3d690" />
2. 3글자 미만으로 입력하고 창을 벗어나면, 에러 메시지
<img width="1112" height="408" alt="image" src="https://github.com/user-attachments/assets/df9fca37-1752-437a-ace8-577678c3c475" />
