### PR TITLE
feat(settings) :개정 설정 페이지 핸들 수정 기능 개선

### DIFF
--- a/app/features/profile/components/FormField.module.scss
+++ b/app/features/profile/components/FormField.module.scss
@@ -1,0 +1,46 @@
+@use 'styles/layout' as layout;
+
+.formFieldGroup {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.input {
+  height: 44px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid layout.$border-color;
+  font-size: 14px;
+  box-sizing: border-box;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: #000;
+    box-shadow: 0 0 0 1px #000;
+  }
+
+  &[aria-invalid='true'] {
+    border-color: layout.$error-color;
+
+    &:focus {
+      box-shadow: 0 0 0 1px layout.$error-color;
+    }
+  }
+}
+
+.error {
+  color: layout.$error-color;
+  font-size: 12px;
+  margin: 6px 0 0 0;
+}

--- a/app/features/profile/components/FormField.tsx
+++ b/app/features/profile/components/FormField.tsx
@@ -1,0 +1,27 @@
+import { ComponentProps } from 'react';
+
+import styles from './FormField.module.scss';
+
+interface FormFieldProps extends ComponentProps<'input'> {
+  label: string;
+  id: string;
+  error?: string;
+}
+
+export function FormField({ label, id, error, ...inputProps }: FormFieldProps) {
+  const errorId = error ? `${id}-error` : undefined;
+
+  return (
+    <div className={styles.formFieldGroup}>
+      <label htmlFor={id} className={styles.label}>
+        {label}
+      </label>
+      <input id={id} className={styles.input} aria-invalid={!!error} aria-describedby={errorId} {...inputProps} />
+      {error && (
+        <p id={errorId} className={styles.error}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/features/profile/loader.ts
+++ b/app/features/profile/loader.ts
@@ -6,7 +6,13 @@ import { getCurrentDBUser, getCurrentUser } from 'app/external/auth/jwt.server';
 import createLoader from 'app/utils/createLoader';
 
 import { searchSongInputLoader } from './components/SearchSongInputloader';
-import { fetchUserMusicMemo, fetchUserWithRecomandSong, findUserByHandleSim, getRecommendedUsers } from './services';
+import {
+  fetchAccountSettingsData,
+  fetchUserMusicMemo,
+  fetchUserWithRecomandSong,
+  findUserByHandleSim,
+  getRecommendedUsers,
+} from './services';
 
 export const profileLayoutLoader = createLoader(async ({ request, db }) => {
   const user = await getCurrentDBUser(request, db);
@@ -90,11 +96,21 @@ export const editHandleLoader = createLoader(async ({ request }) => {
   return { userId: user.id };
 });
 
-export const settingsLoader = createLoader(async () => {
+export const settingsLoader = createLoader(async ({ request, db }) => {
+  const user = await getCurrentUser(request);
+  if (!user) {
+    throw redirect('/login/error', { status: 401 });
+  }
+
+  const settingsData = await fetchAccountSettingsData(db)({ id: user.id });
+
+  if (!settingsData) {
+    throw redirect('/login/error', { status: 404 });
+  }
+
   return {
-    user: {
-      nickname: '',
-      avatarUrl: '/images/features/profile/profile_test.png',
-    },
+    userId: user.id,
+    handle: settingsData.handle,
+    avatarUrl: '/images/features/profile/profile_test.png', //TODO: settingsData.avartarUrl으로 추수 수정
   };
 });

--- a/app/features/profile/pages/setting.module.scss
+++ b/app/features/profile/pages/setting.module.scss
@@ -14,15 +14,12 @@
   background: #fff;
   border: 1px solid #eee;
   border-radius: 12px;
-  padding: 20px;
-  display: grid;
-  gap: 16px;
+  padding: 24px;
 }
 
-.avatarWrap {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 4px;
+.formGrid {
+  display: grid;
+  gap: 16px;
 }
 
 .avatar {
@@ -32,29 +29,10 @@
   object-fit: cover;
   background: #e5e5e5;
   border: 1px solid #ddd;
-}
-
-.labelWrap {
-  display: block;
-}
-
-.label {
-  font-size: 12px;
-  color: #666;
-  margin-bottom: 6px;
-}
-
-.input {
-  width: 100%;
-  height: 44px;
-  padding: 1px;
-  border-radius: 8px;
-  border: 1px solid #ddd;
-  font-size: 14px;
+  justify-self: center;
 }
 
 .button {
-  margin-top: 12px;
   height: 44px;
   width: 100%;
   border-radius: 8px;
@@ -62,12 +40,16 @@
   background: #000;
   color: #fff;
   font-weight: 600;
+  cursor: pointer;
 }
 
-.sectionDivider {
-  height: 1px;
-  background: #000;
-  opacity: 0.15;
-  margin: 24px 0;
-  border: 0;
+.errorContainer {
+  min-height: 24px;
+  margin-top: 8px;
+}
+
+.error {
+  color: #e53e3e;
+  font-size: 14px;
+  margin: 0;
 }

--- a/app/features/profile/pages/settings.tsx
+++ b/app/features/profile/pages/settings.tsx
@@ -3,36 +3,40 @@ import { useLoaderData, useActionData, useNavigation, Form } from '@remix-run/re
 import { settingsAction } from '../action';
 import { settingsLoader } from '../loader';
 import styles from './setting.module.scss';
+import { useHandleValidation } from './useHandleValidation';
+import { FormField } from '../components/FormField';
 
 export default function SettingsPage() {
-  const { user } = useLoaderData<typeof settingsLoader>();
+  const loaderData = useLoaderData<typeof settingsLoader>();
   const actionData = useActionData<typeof settingsAction>();
   const nav = useNavigation();
   const isSubmitting = nav.state === 'submitting';
 
-  const currentNickname = actionData?.nickname ?? user.nickname;
+  const { handle, clientError, handleInputChange, handleInputBlur } = useHandleValidation(loaderData.handle || '');
+
+  const errorMessage = actionData?.error || clientError;
 
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>계정 설정</h1>
-
       <section className={styles.card}>
-        <Form method="post" replace>
-          <div className={styles.avatarWrap}>
-            <img src={user.avatarUrl} alt="프로필 사진" className={styles.avatar} />
-          </div>
+        <Form method="post" replace className={styles.formGrid}>
+          <img src={loaderData.avatarUrl} alt="프로필 사진" className={styles.avatar} />
 
-          <label className={styles.labelWrap}>
-            <div className={styles.label}>닉네임</div>
-            <input
-              name="nickname"
-              defaultValue={currentNickname}
-              placeholder="수정할 닉네임을 입력하세요"
-              className={styles.input}
-            />
-          </label>
-
-          <button type="submit" className={styles.button} disabled={isSubmitting}>
+          <FormField
+            label="핸들"
+            id="handle-input"
+            name="handle"
+            type="text"
+            placeholder="수정할 핸들을 입력하세요."
+            required
+            value={handle}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            error={errorMessage}
+          />
+          <input type="hidden" name="userId" value={loaderData.userId} />
+          <button type="submit" className={styles.button} disabled={isSubmitting || !!clientError}>
             {isSubmitting ? '저장 중…' : '저장'}
           </button>
         </Form>

--- a/app/features/profile/pages/useHandleValidation.ts
+++ b/app/features/profile/pages/useHandleValidation.ts
@@ -2,8 +2,8 @@ import { useState } from 'react';
 
 import { HandleCharacterSchema, HandleSchema } from '../schema';
 
-export function useHandleValidation() {
-  const [handle, setHandle] = useState('');
+export function useHandleValidation(initialValue = '') {
+  const [handle, setHandle] = useState(initialValue);
   const [clientError, setClientError] = useState('');
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/features/profile/services.ts
+++ b/app/features/profile/services.ts
@@ -91,3 +91,21 @@ export const updateUserHandle = createService<{ userId: string; handle: string }
     });
   }
 );
+
+//TODO: avartarUrl 필드 생성 후 주석 제거
+export interface AccountSettingData {
+  handle: string | null;
+  // avartalUrl: string | null;
+}
+
+export const fetchAccountSettingsData = createService<{ id: number }, AccountSettingData | null>(async (db, { id }) => {
+  const user = await db.user.findUnique({
+    where: { id },
+    select: {
+      handle: true,
+      // avartarUrl: true,
+    },
+  });
+
+  return user;
+});

--- a/styles/_layout.scss
+++ b/styles/_layout.scss
@@ -21,3 +21,9 @@ $breakpoint-desktop: 1024px;
     @content;
   }
 }
+
+$grey-n00: #ddd;
+$red-n00: #d93025;
+
+$border-color: $grey-n00;
+$error-color: $red-n00;


### PR DESCRIPTION
## ✨ 개요
계정 설정 페이지의 핸들 수정 기능을 전체적으로 개선하고 리팩토링함

## 변경 사항
- `settingsLoader`: DB에서 사용자 실제 `handle`, `(추후)avartarUrl`을 전달하도록 수정
- `fetchAccountSettinigsData`서비스: loader에서 사용할 `id`로 `handle`, `avartarUrl` 조회하는 서비스 함수
- `FormField` 컴포넌트: 입력 필드를 재사용 가능한 `FormFiled`컴포넌트로 분리
- `userHandleValidation`: 핸들 수정 시 기존 핸들이 미리 채워져 있어 UX 개선을 위해 `initValue`받도록 수정 (인스타그램 참고)
- `settingsAction`: 서버 유효성 검사 추가

## 스크린샷
<img width="620" height="408" alt="image" src="https://github.com/user-attachments/assets/94970d2b-2981-4ff6-9c76-6cc4d1c79ae1" />

- Closes #129 