### PR TITLE
feat: 페이지 접근 권한 제어 및 공통 에러 처리 기능 구현

### DIFF
--- a/app/features/music/action.tsx
+++ b/app/features/music/action.tsx
@@ -1,8 +1,10 @@
 import { redirect } from '@remix-run/server-runtime';
 
+import { requireUserOwnership } from 'app/external/auth/jwt.server';
 import createAction from 'app/utils/createAction';
 
-export const createUserMusicMemoAction = createAction(async ({ db, request }) => {
+export const createUserMusicMemoAction = createAction(async ({ db, request, params }) => {
+  await requireUserOwnership(request, { userId: params.userId });
   console.log('1231241243');
   const formdata = await request.formData();
 
@@ -21,7 +23,9 @@ export const createUserMusicMemoAction = createAction(async ({ db, request }) =>
   return redirect('..');
 });
 
-export const editUserMusicMemoAction = createAction(async ({ db, request }) => {
+export const editUserMusicMemoAction = createAction(async ({ db, request, params }) => {
+  await requireUserOwnership(request, { userId: params.userId });
+
   const formdata = await request.formData();
   const id = Number(formdata.get('userMusicMemoId'));
   const content = formdata.get('content') as string;

--- a/app/features/music/loader.tsx
+++ b/app/features/music/loader.tsx
@@ -1,6 +1,6 @@
 import { redirect } from '@remix-run/server-runtime';
 
-import { getCurrentUser } from 'app/external/auth/jwt.server';
+import { getCurrentUser, requireUserOwnership } from 'app/external/auth/jwt.server';
 import createLoader from 'app/utils/createLoader';
 
 export const musicUserLoader = createLoader(async ({ db, params, request }) => {
@@ -19,6 +19,8 @@ export const musicUserLoader = createLoader(async ({ db, params, request }) => {
 });
 
 export const musicCreateUserLoader = createLoader(async ({ db, params, request }) => {
+  await requireUserOwnership(request, { userId: params.userId });
+
   const songId = Number(params.songId);
   const userId = Number(params.userId);
 

--- a/app/features/profile/action.ts
+++ b/app/features/profile/action.ts
@@ -1,11 +1,13 @@
 import { data, redirect } from '@remix-run/node';
 
+import { requireUserOwnership } from 'app/external/auth/jwt.server';
 import { findUserByHandle, updateUserHandle } from 'app/features/profile/services';
 import createAction from 'app/utils/createAction';
 
 import { HandleSchema } from './schema';
 
 export const addTodaySongAction = createAction(async ({ request, db, params }) => {
+  await requireUserOwnership(request, { userId: params.userId });
   const formData = await request.formData();
 
   const handle = (formData.get('handle') as string | null)?.trim() ?? '';
@@ -46,7 +48,9 @@ export const addTodaySongAction = createAction(async ({ request, db, params }) =
   return redirect('../show');
 });
 
-export const editHandleAction = createAction(async ({ request, db }) => {
+export const editHandleAction = createAction(async ({ request, db, params }) => {
+  await requireUserOwnership(request, { userId: params.userId });
+
   const formData = await request.formData();
 
   const formPayload = {
@@ -68,7 +72,9 @@ export const editHandleAction = createAction(async ({ request, db }) => {
   }
 });
 
-export const settingsAction = createAction(async ({ request, db }) => {
+export const settingsAction = createAction(async ({ request, db, params }) => {
+  await requireUserOwnership(request, { userId: params.userId });
+
   const formData = await request.formData();
 
   const formPayload = {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,15 @@
 import type { LinksFunction } from '@remix-run/node';
-import { Links, Meta, Outlet, Scripts, ScrollRestoration, useNavigation } from '@remix-run/react';
+import {
+  isRouteErrorResponse,
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useNavigate,
+  useNavigation,
+  useRouteError,
+} from '@remix-run/react';
 import NProgress from 'nprogress';
 import { useEffect } from 'react';
 
@@ -67,18 +77,19 @@ export default function App() {
   return <Outlet />;
 }
 
-export function ErrorBoundary({ error }: { error: Error }) {
-  console.error(error);
-  return (
-    <html>
-      <head>
-        <title>Error</title>
-      </head>
-      <body>
-        <h1>Oops! Something went wrong.</h1>
-        <p>{error?.message}</p>
-        <Scripts />
-      </body>
-    </html>
-  );
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isRouteErrorResponse(error)) {
+      alert(error.data);
+      navigate(-1);
+    }
+  }, [error, navigate]);
+
+  if (isRouteErrorResponse(error)) {
+    return null;
+  }
+  return <div>예상치 못한 오류가 발생했습니다.</div>;
 }


### PR DESCRIPTION
### ✨ 주요 변경 사항
- **`requreUserOwnership` 유틸리티 함수 추가:** 현재 로그인한 사용자와 페이지의 소유자가 일치하는지 확인하는 권한 검사 로직
- 각 페이지 로더/액션에 권한 검사 적용:
   - `addTodaySong`
   - `editHandle`
   - `editList`
   - `settings`
   - `music` (메모 추가 및 수정)
   - 위 페이지들의 `loader`와 `action`에 `requireUserOwnership`을 적용하여, 권한이 없는 사용자의 접근을 서버에서 차단함
- **`ErrorBoundary` 컴포넌트:**
   - `requireUserOwnership`에서 에러가 발생하면, 이를 처리하는 공통 컴포넌트
   - 권한이 없는 사용자에게 "접근 권한이 없습니다." `alert`를 보여주고, 이전 페이지로 자동 이동시킴
 
### 📸 스크린샷
<img width="916" height="304" alt="image" src="https://github.com/user-attachments/assets/723ede2a-9ba5-4905-8807-72298a15aed0" />

### 🎯 관련 이슈
- close #140 