### PR TITLE
feat(spotify): 스포티파이 검색 시 한국어 제목 우선 표시

### DIFF
--- a/app/external/music/SpotifyAPI.ts
+++ b/app/external/music/SpotifyAPI.ts
@@ -64,9 +64,11 @@ export class SpotifyAPI {
           q: query,
           type: 'track',
           limit: 20,
+          market: 'KR',
         },
         headers: {
           Authorization: `Bearer ${token}`,
+          'Accept-Language': 'ko-KR, ko;q=0.9',
         },
         timeout: 5000,
       });


### PR DESCRIPTION
## ✨ 주요 변경 사항
Spotify API 검색 결과로 한국어 제목 우선 적용

## 📸 스크린샷
<img width="895" height="170" alt="image" src="https://github.com/user-attachments/assets/1752d7f2-d4e8-489d-b1fe-fe870fdab695" />

## 🎯 관련 이슈
- close #144 