### PR TITLE
feat: 추천 유저 생성 및 적용

### DIFF
--- a/app/features/profile/services.ts
+++ b/app/features/profile/services.ts
@@ -65,10 +65,15 @@ export const findUserByHandleSim = createService<{ handle: string }, UserWithRec
 export const getRecommendedUsers = createService<Record<string, never>, UserWithRecommendedSong[]>(
   async (db, _args) => {
     const users = await db.user.findMany({
-      take: 6,
+      where: {
+        id: {
+          gte: 20,
+          lte: 25,
+        },
+      },
       include: { todayRecommendedSong: true },
     });
-    // TODO: avatarUrl 추가 필요(현재는 랜덤)
+    // TODO: avatarUrl 추가 필요
     return users.map((user) => ({
       ...user,
       avatarUrl: `https://i.pravatar.cc/150?u=${user.handle}`,


### PR DESCRIPTION
## ✨ 주요 변경 사항
- **6명의 유저 생성**
   1. 감성적 일기 `hye_rin_s`
   2. kpop 추천 `chaechae_log`
   3. 여행 기록 `jj_yeo`
   4. 에너지 유저 `jun_seo_k`
   5. 일상 유저 `its_heon`
   6. 가사 인용 유저 `woo_suk`
   <img width="489" height="194" alt="image" src="https://github.com/user-attachments/assets/f084cc3a-a3b9-40d8-826e-fa7215c21be6" />

- **`search` 페이지 방문 시, 위 6 유저 추천 사용자로 띄우기**

---
## 🎯 관련 이슈
- Close #135  
