### PR TITLE
feat:  메모히스토리 그리드 UI 구현

### DIFF
--- a/app/features/profile/components/MemoGridItem.module.scss
+++ b/app/features/profile/components/MemoGridItem.module.scss
@@ -1,0 +1,71 @@
+@use 'styles/layout' as *;
+
+.memo-grid-item {
+  display: block;
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  cursor: pointer;
+  border-radius: 4px;
+
+  .item-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition:
+      transform 0.3s ease,
+      filter 0.3s ease;
+  }
+
+  .info-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+
+    background: $overlay-dark-60;
+    color: white;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+
+    opacity: 0;
+    transition: opacity 0.3s ease;
+
+    padding: 0 15px;
+    box-sizing: border-box;
+
+    .title {
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-align: center;
+      width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .artist {
+      font-size: 0.7rem;
+      width: 100%;
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  &:hover {
+    .item-image {
+      transform: scale(1.05);
+      filter: brightness(0.8);
+    }
+    .info-overlay {
+      opacity: 1;
+    }
+  }
+}

--- a/app/features/profile/components/MemoGridItem.tsx
+++ b/app/features/profile/components/MemoGridItem.tsx
@@ -1,0 +1,23 @@
+import { Song } from '@prisma/client';
+
+import styles from './MemoGridItem.module.scss';
+
+interface MemoGridItemProps {
+  song: Song;
+}
+
+export default function MemoGridItem({ song }: MemoGridItemProps) {
+  return (
+    <div className={styles.memoGridItem}>
+      <img
+        className={styles.itemImage}
+        src={song.thumbnailUrl ?? '/images/features/profile/album_default2.png'}
+        alt={`${song.title}`}
+      />
+      <div className={styles.infoOverlay}>
+        <p className={styles.title}>{song.title}</p>
+        <p className={styles.artist}>{song.artist}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/features/profile/pages/show.module.scss
+++ b/app/features/profile/pages/show.module.scss
@@ -60,15 +60,30 @@
   }
 }
 
-.song-box {
-  display: flex;
-  flex-direction: column;
-  padding: 12px;
-  gap: 12px;
+.song-item-box {
+  padding: 10px;
   background: $grey-100;
-  border-radius: 8px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   a {
     text-decoration: none;
     color: inherit;
+  }
+}
+
+.memo-items-box {
+  display: grid;
+  padding: 4px;
+  gap: 2px;
+  background: $grey-100;
+  border-radius: 10px;
+  min-width: 0;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+
+  a {
+    text-decoration: none;
+    color: inherit;
+    min-width: 0;
   }
 }

--- a/app/features/profile/pages/show.tsx
+++ b/app/features/profile/pages/show.tsx
@@ -5,6 +5,7 @@ import SongItem from 'app/features/profile/components/SongItem';
 import { profileLayoutLoader, profileLoader } from 'app/features/profile/loader';
 import styles from 'app/features/profile/pages/show.module.scss';
 
+import MemoGridItem from '../components/MemoGridItem';
 import { SortToggle } from '../components/SortToggle';
 
 export default function Show() {
@@ -36,11 +37,11 @@ export default function Show() {
             <p className={styles.title}> {isCurrentUserProfile ? '내가' : `${user.handle}이(가)`} 쓴 메모들</p>
             <SortToggle currentSort={currentSort} />
           </div>
-          <div className={styles.songBox}>
+          <div className={styles.memoItemsBox}>
             {userMusicMemo.length > 0 ? (
               userMusicMemo.map((musicMemo) => (
                 <Link key={musicMemo.song.id} to={`/music/${musicMemo.song.id}/user/${user.id}`}>
-                  <SongItem song={musicMemo.song} />
+                  <MemoGridItem song={musicMemo.song} />
                 </Link>
               ))
             ) : (
@@ -70,7 +71,7 @@ export function TodaySongSection({ song, isCurrentUserProfile, userId }: TodaySo
           </Link>
         )}
       </div>
-      <div className={styles.songBox}>
+      <div className={styles.songItemBox}>
         {song && song.title ? (
           <Link to={`/music/${song.id}/user/${userId}`}>
             <SongItem song={song as Song} />

--- a/styles/_variable.scss
+++ b/styles/_variable.scss
@@ -17,6 +17,9 @@ $primary-300: hsl(25, 70%, 80%);
 $primary-400: hsl(25, 60%, 75%);
 $primary-500: hsl(25, 60%, 60%);
 
+$overlay-dark-60: hsla(0, 0%, 0%, 0.6);
+$shadow-color: hsla(0, 0%, 0%, 0.05);
+
 $red-400: hsl(3, 71%, 50%);
 
 $primary-font: $black-500;


### PR DESCRIPTION
## ✨ 주요 변경 사항
- **`MemoGridItem`** 컴포넌트 구현
  - 메모를 앨범 커버 중심으로 보여주는 그리드 아이템 컴포넌트
  - 마우스 호버 시, 곡 제목과 아티스트 이름이 나타남
- **반응형 그리드 레이아웃 적용**

## 📸 스크린샷
| 데스크톱(넓은) | 데스크톱(중간) | 모바일 |
| :------------: | :--------------: | :--------------:|
| <img width="3404" height="1882" alt="image" src="https://github.com/user-attachments/assets/b55c1d1c-ceaa-4777-b3ca-95b073e2883f" /> | <img width="1894" height="1884" alt="image" src="https://github.com/user-attachments/assets/8856708c-9fb2-40b8-b18c-c0fedede83c2" /> | <img width="1179" height="2270" alt="image" src="https://github.com/user-attachments/assets/94f28014-a4b8-4d96-8fcd-54cc3f0ee41a" /> |

[호버 시 - 곡 제목과 아티스트 이름]
<img width="1362" height="792" alt="image" src="https://github.com/user-attachments/assets/428c2a1b-506f-4d7b-8bc0-d7e10ef88d62" />

## 🎯 관련 이슈
- closes #130 

