### PR TITLE
feat: Spotify 플레이어 임베드 세팅

### DIFF
--- a/app/external/music/IMusicSearchAPI.ts
+++ b/app/external/music/IMusicSearchAPI.ts
@@ -9,6 +9,7 @@ export interface MusicInfo {
   artist: string;
   album: string;
   mbid?: string;
+  spotifyId: string;
   albumCover?: Promise<string>;
 }
 

--- a/app/external/music/SpotifyAPI.ts
+++ b/app/external/music/SpotifyAPI.ts
@@ -83,6 +83,7 @@ export class SpotifyAPI {
         artist: item.artists?.[0]?.name || '',
         album: item.album.name,
         mbid: item.id,
+        spotifyId: item.id,
         albumCover: item.album.images?.[0]?.url || '',
       }));
     } catch (error) {

--- a/app/external/music/SpotifyOEmbed.ts
+++ b/app/external/music/SpotifyOEmbed.ts
@@ -1,0 +1,35 @@
+export interface SpotifyEmbedData {
+  html: string;
+  width: number;
+  height: number;
+  title: string;
+  author_name: string;
+  thumbnail_url: string;
+}
+
+export async function getSpotifyEmbed(trackUrl: string): Promise<SpotifyEmbedData | null> {
+  try {
+    const response = await fetch(`https://open.spotify.com/oembed?url=${encodeURIComponent(trackUrl)}&format=json`);
+
+    if (!response.ok) {
+      throw new Error(`Spotify oEmbed API 요청 실패: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return {
+      html: data.html,
+      width: data.width,
+      height: data.height,
+      title: data.title,
+      author_name: data.author_name,
+      thumbnail_url: data.thumbnail_url,
+    };
+  } catch (error) {
+    console.error(`Failed to fetch Spotify embed: ${error}`);
+    return null;
+  }
+}
+
+export function buildSpotifyTrackUrl(trackId: string): string {
+  return `https://open.spotify.com/track/${trackId}`;
+}

--- a/app/features/profile/action.ts
+++ b/app/features/profile/action.ts
@@ -29,6 +29,7 @@ export const addTodaySongAction = createAction(async ({ request, db, params }) =
   const artist = (formData.get('artist') as string | null)?.trim() ?? '';
   const album = (formData.get('album') as string | null)?.trim() || null;
   const thumbnailUrl = (formData.get('thumbnailUrl') as string | null)?.trim() || null;
+  const spotifyId = (formData.get('spotifyId') as string | null)?.trim() || null;
 
   if (!title || !artist) {
     return new Response('제목과 아티스트는 필수입니다.', { status: 400 });
@@ -36,8 +37,12 @@ export const addTodaySongAction = createAction(async ({ request, db, params }) =
 
   const song = await db.song.upsert({
     where: { title_artist: { title, artist } },
-    create: { title, artist, album, thumbnailUrl },
-    update: {},
+    create: { title, artist, album, thumbnailUrl, spotifyId },
+    update: {
+      album,
+      thumbnailUrl,
+      spotifyId,
+    },
   });
 
   await db.user.update({

--- a/app/features/profile/loader.ts
+++ b/app/features/profile/loader.ts
@@ -3,6 +3,7 @@ import { redirect } from '@remix-run/react';
 
 import { authenticator } from 'app/external/auth/auth.server';
 import { getCurrentDBUser, getCurrentUser, requireUserOwnership } from 'app/external/auth/jwt.server';
+import { buildSpotifyTrackUrl, getSpotifyEmbed, SpotifyEmbedData } from 'app/external/music/SpotifyOEmbed';
 import createLoader from 'app/utils/createLoader';
 
 import { searchSongInputLoader } from './components/SearchSongInputloader';
@@ -38,7 +39,19 @@ export const profileLoader = createLoader(async ({ db, params, request }) => {
   const userMusicMemo = await fetchUserMusicMemo(db)({ userId: profileUserId, sortOrder: sortOrder });
   const isFollowing = await isUserFollowing(db)({ followerId: currentUser.id, followingId: profileUser.id });
 
-  return { user: profileUser, userMusicMemo, isFollowing };
+  let spotifyEmbed: SpotifyEmbedData | null = null;
+  if (profileUser.todayRecommendedSong?.spotifyId) {
+    try {
+      const spotifyUrl = buildSpotifyTrackUrl(profileUser.todayRecommendedSong.spotifyId);
+      if (spotifyUrl) {
+        spotifyEmbed = await getSpotifyEmbed(spotifyUrl);
+      }
+    } catch (error) {
+      console.error(`Failed to fetch Spotify embed: ${error}`);
+    }
+  }
+
+  return { user: profileUser, userMusicMemo, isFollowing, spotifyEmbed };
 });
 
 export const profileRedirectLoader = createLoader(async ({ request }) => {
@@ -69,6 +82,7 @@ export const addTodaySongLoader = createLoader(async ({ db, params, request }) =
           artist: true,
           album: true,
           thumbnailUrl: true,
+          spotifyId: true,
         },
       },
     },

--- a/app/features/profile/pages/addTodaySong.tsx
+++ b/app/features/profile/pages/addTodaySong.tsx
@@ -54,6 +54,7 @@ const useSavePickedSong = () => {
     fd.append('artist', simple.artist);
     fd.append('album', simple.album ?? '');
     fd.append('thumbnailUrl', simple.thumbnailUrl ?? '');
+    fd.append('spotifyId', song.spotifyId ?? '');
     submit(fd, { method: 'post' });
   };
 };

--- a/prisma/migrations/20251002141603_add_spotify_id_to_song/migration.sql
+++ b/prisma/migrations/20251002141603_add_spotify_id_to_song/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Song" ADD COLUMN     "spotifyId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Song {
   artist                String
   thumbnailUrl          String?
   album                 String?
+  spotifyId             String?      
   rankings              UserRanking[]
   usersTodayRecommended User[]
   UserMusicMemo         UserMusicMemo[]


### PR DESCRIPTION
## ✨ 주요 변경사항
**1. DB 스키마에 `spotifyId` 추가**
**2. `SpotifyAPI.ts`, `IMusicSearchAPI.ts`에 `spotifyId` 추가**
**3. Spotify oEmbed API 유틸리티 추가**
   - `getSpotifyEmbed(trackUrl)`: Spotify oEmbed API 호출
   - `buildSpotifyTrackUrl(trackId)`: Spotify URL 생성
   - `extractSpotifyTrackId(url)`: URL에서 ID 추출 (유틸)
   - `isValidSpotifyTrackUrl(url)`: URL 유효성 검사 (유틸)
  
**4. 데이터 저장**
- `addTodaySong.tsx` : FormData에 `spotifyId` 추가
- `action.ts` : DB upsert 시 `spotifyId` 저장

**5.  SSR** 
- `loader.ts` : `spotifyEmbed` 데이터 로드 준비

## 🐽 다음 작업
- Spotify 플레이어 UI 컴포넌트 추가