### PR TITLE
Ingress에 이미지 서버 도메인 추가 (file.formabridge.cc)

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -2,19 +2,39 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: project-alpha-ingress
+  namespace: default
   annotations:
-    # 이 annotation은 Nginx Ingress Controller에게 경로를 재작성하도록 지시합니다.
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"  # MinIO 업로드 허용
 spec:
   ingressClassName: nginx
   rules:
   - host: music.formabridge.cc
     http:
       paths:
-      - path: /()(.*)
-        pathType: ImplementationSpecific
+      - path: /
+        pathType: Prefix
         backend:
           service:
             name: project-alpha-service
             port:
               number: 80
+  - host: file.formabridge.cc
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: minio-service
+            port:
+              number: 9000
+  - host: file-console.formabridge.cc
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: minio-service
+            port:
+              number: 9001

--- a/k8s/minio-deployment.yaml
+++ b/k8s/minio-deployment.yaml
@@ -1,0 +1,57 @@
+# ------------------- Service ------------------- #
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  type: ClusterIP   # 내부 접근용 (Ingress 붙이기 전)
+
+---
+# ----------------- StatefulSet ----------------- #
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minio-statefulset
+spec:
+  serviceName: "minio-service"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio
+          args: ["server", "/data", "--console-address", ":9001"]
+          ports:
+            - containerPort: 9000   # S3 API
+            - containerPort: 9001   # Web Console
+          envFrom:
+            - secretRef:
+                name: minio-secret
+          volumeMounts:
+            - name: minio-storage
+              mountPath: /data
+              subPath: minio-data
+  volumeClaimTemplates:
+    - metadata:
+        name: minio-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: nhn-block-storage
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
## 요약
- file.formabridge.cc → minio-service:9000 라우팅 추가
- 기존 music.formabridge.cc → project-alpha-service:80 유지
- 업로드 제한 해제: proxy-body-size: "0"
## 변경 사항 (Ingress)
```yaml
rules:
  - host: music.formabridge.cc
    http:
      paths:
        - path: /
          pathType: Prefix
          backend:
            service:
              name: project-alpha-service
              port:
                number: 80
  - host: file.formabridge.cc
    http:
      paths:
        - path: /
          pathType: Prefix
          backend:
            service:
              name: minio-service
              port:
                number: 9000
```
## 적용/검증
```bash
kubectl -n default apply -f k8s/ingress.yaml
kubectl describe ingress project-alpha-ingress -n default
curl -I https://music.formabridge.cc
curl -I https://file.formabridge.cc/minio/health/ready
```
## 메모
- 필요 시 콘솔: console.formabridge.cc → minio-service:9001 추가 가능
- TLS는 Cloudflare 설정으로 운영 예정