### PR TITLE
feat(search): show페이지 상단 searchBar UI

### DIFF
--- a/app/components/SearchBar.module.scss
+++ b/app/components/SearchBar.module.scss
@@ -1,0 +1,42 @@
+@use 'styles/layout' as *;
+
+.root {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 12px 8px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+}
+
+.logo {
+  font-size: 35px;
+  text-decoration: none;
+  color: black;
+
+  @include mobile {
+    font-size: 25px;
+  }
+}
+
+.input {
+  flex: 1 1 auto;
+  max-width: 800px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.04);
+  height: 40px;
+
+  @include mobile {
+    height: 36px;
+  }
+}
+
+.input::placeholder {
+  color: rgba(0, 0, 0, 0.45);
+}

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -1,0 +1,20 @@
+import { Form } from '@remix-run/react';
+
+import styles from './SearchBar.module.scss';
+
+export const SearchBar = () => {
+  return (
+    <Form method="get" action="/search" role="search" className={styles.root}>
+      <a href="/" className={styles.logo}>
+        Sonnets
+      </a>
+      <input
+        className={styles.input}
+        type="text"
+        name="search"
+        placeholder="음악, 메모, 사용자를 검색해보세요"
+        autoComplete="on"
+      />
+    </Form>
+  );
+};

--- a/app/features/profile/pages/show.tsx
+++ b/app/features/profile/pages/show.tsx
@@ -1,6 +1,7 @@
 import type { Song } from '@prisma/client';
 import { Link, useLoaderData, useRouteLoaderData, useSearchParams, Form } from '@remix-run/react';
 
+import { SearchBar } from 'app/components/SearchBar';
 import { profileLayoutLoader, profileLoader } from 'app/features/profile/loader';
 import styles from 'app/features/profile/pages/show.module.scss';
 
@@ -19,6 +20,7 @@ export default function Show() {
 
   return (
     <div>
+      <SearchBar />
       <TodaySongSection song={user.todayRecommendedSong} isCurrentUserProfile={isCurrentUserProfile} userId={user.id} />
       <div className={styles.profileBox}>
         <img


### PR DESCRIPTION
## ✨ 주요 변경 사항
- SearchBar 컴포넌트
   - `SearchBar.tsx`, `SearchBar.module.scss`
   - `Show`페이지 상단에 위치

## 📸 스크린샷
<img width="3390" height="1966" alt="image" src="https://github.com/user-attachments/assets/a039378b-72a9-447a-a78a-4f6d68f21d2c" />
