### PR TITLE
feat(music): 음악 메모 좋아요 버튼 UI 추가 및 낙관적 업데이트 적용

### DIFF
--- a/app/features/music/pages/music.user.module.scss
+++ b/app/features/music/pages/music.user.module.scss
@@ -145,11 +145,15 @@
   gap: 8px;
   padding: 8px 12px;
   border-radius: 999px;
-  border: 1px solid #e5e7eb; 
-  background: #f9fafb;        
-  color: #6b7280;             
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  color: #6b7280;
   cursor: pointer;
-  transition: transform 120ms ease, background 160ms ease, color 160ms ease, border-color 160ms ease;
+  transition:
+    transform 120ms ease,
+    background 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease;
   will-change: transform;
 
   &:hover:not(:disabled) {
@@ -169,9 +173,9 @@
 }
 
 .liked {
-  background: #fee2e2;   
-  color: #ef4444;        
-  border-color: #fecaca; 
+  background: #fee2e2;
+  color: #ef4444;
+  border-color: #fecaca;
 
   .heart {
     animation: pulse 280ms ease;
@@ -186,7 +190,9 @@
   width: 18px;
   height: 18px;
   flex: 0 0 18px;
-  transition: fill 0.2s ease, transform 0.2s ease;
+  transition:
+    fill 0.2s ease,
+    transform 0.2s ease;
 }
 
 .liked .heart {
@@ -203,14 +209,25 @@
 }
 
 @keyframes pulse {
-  0%   { transform: scale(0.9); }
-  60%  { transform: scale(1.08); }
-  100% { transform: scale(1); }
+  0% {
+    transform: scale(0.9);
+  }
+  60% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 @keyframes breathe {
-  0%   { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.0); }
-  50%  { box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.06); }
-  100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.0); }
+  0% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.06);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
 }
-

--- a/app/features/music/pages/music.user.tsx
+++ b/app/features/music/pages/music.user.tsx
@@ -67,7 +67,15 @@ const MemoHeader = ({ spotifyEmbed, UserMusicMemo, song }: MemoHeaderProps) => {
   );
 };
 
-const LikeButton = ({likes, memoId: _memoId, isChecked: isMemoLiked }: { likes: number; memoId: number; isChecked: boolean; }) => {
+const LikeButton = ({
+  likes,
+  memoId: _memoId,
+  isChecked: isMemoLiked,
+}: {
+  likes: number;
+  memoId: number;
+  isChecked: boolean;
+}) => {
   const fetcher = useFetcher();
   const submitting = fetcher.state !== 'idle';
   const intentInFlight = fetcher.formData?.get('intent') as 'like' | 'unlike' | undefined;


### PR DESCRIPTION
## 개요 #185 
- 음악 메모 상세 페이지에 좋아요 버튼을 추가하고 낙관적 업데이트를 적용함.
- 전송 중 중복 클릭 방지, 접근성 속성, 경고 제거를 포함.
- SCSS Modules는 기존 컨벤션(kebab-case in SCSS, camelCase in TSX)을 유지.

## 변경 사항
- app/features/music/pages/music.user.tsx
  - LikeButton 컴포넌트 추가
  - useFetcher 기반 낙관적 업데이트 적용
  - 전송 중 상태(submitting)에서 버튼 비활성화
  - aria-pressed, aria-live 등 접근성 보강
  - 미사용 변수 경고 해결을 위해 memoId를 _memoId로 리네임
- app/features/music/pages/music.user.module.scss
  - like-form, like-button, liked, loading, heart, like-count 스타일 추가
  - 하트 아이콘 애니메이션(pulse) 및 전송 중 breathe 효과 추가
  - 페이지 레이아웃 관련 클래스는 기존 컨벤션 유지
- 아이콘
  - outline 스타일 하트 SVG로 교체, currentColor 상속으로 상태 색상 일관성 유지
## 스크린샷
(좋아요 누르기 전)
<img width="915" height="315" alt="스크린샷 2025-10-28 00 34 37" src="https://github.com/user-attachments/assets/6f5d9622-9964-416b-a709-609f4769e357" />

(좋아요 누른 후)
<img width="927" height="314" alt="스크린샷 2025-10-28 00 34 43" src="https://github.com/user-attachments/assets/78540d9f-3d34-4a53-ae0d-cbae065eacff" />
## 추후 작업(동시 접근 대비, 서버 권위적 카운트)
- 목표: 다중 탭/다중 사용자 동시 클릭 시 카운트 불일치 방지, 레이스 컨디션 제거.
- 서버 액션 개선
  - 트랜잭션으로 upsert/deleteMany 후, `memoLikesUser.count`로 정확한 카운트 재계산하여 `userMusicMemo.likes`를 업데이트.
  - 응답 payload에 `likeCount` 포함.
